### PR TITLE
_initMap when element is loaded in a different location

### DIFF
--- a/google-map.js
+++ b/google-map.js
@@ -136,6 +136,10 @@ class GoogleMap extends LitElement {
     this._updateMap(props);
   }
 
+  firstUpdated(props) {
+    if(!this._map && window.google && window.google.maps) this._initMap();
+  }
+
   _initSlot() {
     var slot = this.shadowRoot.querySelector('slot');
     slot.addEventListener('slotchange', this._handleSlotChange.bind(this));


### PR DESCRIPTION
If the element is opened in a second location, the _loadScript method will never call this._initMap() since window.google.maps already exists. Therefore, we need to init the `_map` in a different way (otherwise, the map won't load). Checking on firstUpdated(), with a check on `_map` and `window.google.maps` works.